### PR TITLE
Include old values in JSON Patch entries for REPLACE ops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ apply(plugin: "idea");
 apply(plugin: "eclipse");
 
 group = "com.github.fge";
-version = "1.10-SNAPSHOT";
+version = "1.11-SNAPSHOT";
 description = "JSON Patch (RFC 6902) and JSON Merge Patch (RFC 7386) implementation in Java";
 sourceCompatibility = "1.6";
 targetCompatibility = "1.6"; // defaults to sourceCompatibility

--- a/src/main/java/com/github/fge/jsonpatch/PathValueOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/PathValueOperation.java
@@ -53,8 +53,8 @@ public abstract class PathValueOperation
     }
 
     @Override
-    public final void serialize(final JsonGenerator jgen,
-        final SerializerProvider provider)
+    public void serialize(final JsonGenerator jgen,
+                          final SerializerProvider provider)
         throws IOException, JsonProcessingException
     {
         jgen.writeStartObject();
@@ -66,8 +66,8 @@ public abstract class PathValueOperation
     }
 
     @Override
-    public final void serializeWithType(final JsonGenerator jgen,
-        final SerializerProvider provider, final TypeSerializer typeSer)
+    public void serializeWithType(final JsonGenerator jgen,
+                                  final SerializerProvider provider, final TypeSerializer typeSer)
         throws IOException, JsonProcessingException
     {
         serialize(jgen, provider);

--- a/src/main/java/com/github/fge/jsonpatch/diff/DiffOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/diff/DiffOperation.java
@@ -21,12 +21,7 @@ package com.github.fge.jsonpatch.diff;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
-import com.github.fge.jsonpatch.AddOperation;
-import com.github.fge.jsonpatch.CopyOperation;
-import com.github.fge.jsonpatch.JsonPatchOperation;
-import com.github.fge.jsonpatch.MoveOperation;
-import com.github.fge.jsonpatch.RemoveOperation;
-import com.github.fge.jsonpatch.ReplaceOperation;
+import com.github.fge.jsonpatch.*;
 
 final class DiffOperation
 {
@@ -153,7 +148,7 @@ final class DiffOperation
             @Override
             JsonPatchOperation toOperation(final DiffOperation op)
             {
-                return new ReplaceOperation(op.from, op.value);
+                return new ReplaceOperation(op.from, op.value, op.oldValue);
             }
         },
         ;

--- a/src/test/resources/jsonpatch/diff/diff.json
+++ b/src/test/resources/jsonpatch/diff/diff.json
@@ -52,7 +52,12 @@
         "first": { "a": null },
         "second": { "a": 6 },
         "patch": [
-            { "op": "replace", "path": "/a", "value": 6 }
+            {
+                "op": "replace",
+                "path": "/a",
+                "value": 6,
+                "oldValue": null
+            }
         ]
     },
     {
@@ -60,7 +65,18 @@
         "first": [ 1, 2, 3 ],
         "second": { "hello": "world" },
         "patch": [
-            { "op": "replace", "path": "", "value": { "hello": "world" } }
+            {
+                "op": "replace",
+                "path": "",
+                "value": {
+                    "hello": "world"
+                },
+                "oldValue": [
+                    1,
+                    2,
+                    3
+                ]
+            }
         ]
     },
     {
@@ -80,7 +96,12 @@
         },
         "patch": [
             { "op": "add", "path": "/c/e", "value": "f" },
-            { "op": "replace", "path": "/c/d", "value": 1 }
+            {
+                "op": "replace",
+                "path": "/c/d",
+                "value": 1,
+                "oldValue": "e"
+            }
         ]
     },
     {
@@ -92,7 +113,12 @@
             "a": [ "b", 2, 3, 4 ]
         },
         "patch": [
-            { "op": "replace", "path": "/a/0", "value": "b" },
+            {
+                "op": "replace",
+                "path": "/a/0",
+                "value": "b",
+                "oldValue": 1
+            },
             { "op": "add", "path": "/a/-", "value": 4 }
         ]
     },
@@ -102,7 +128,12 @@
         "second": [ { "a": "b", "c": "d" }, "foo", { "bar": "baz" } ],
         "patch": [
             { "op": "add", "path": "/0/c", "value": "d" },
-            { "op": "replace", "path": "/2/bar", "value": "baz" }
+            {
+                "op": "replace",
+                "path": "/2/bar",
+                "value": "baz",
+                "oldValue": null
+            }
         ]
     },
     {
@@ -110,7 +141,12 @@
         "first": [ 1, [ 2, 3 ], 4 ],
         "second": [ "x", [ 2, 3, "y" ], 4 ],
         "patch": [
-            { "op": "replace", "path": "/0", "value": "x" },
+            {
+                "op": "replace",
+                "path": "/0",
+                "value": "x",
+                "oldValue": 1
+            },
             { "op": "add", "path": "/1/-", "value": "y" }
         ]
     },

--- a/src/test/resources/jsonpatch/replace.json
+++ b/src/test/resources/jsonpatch/replace.json
@@ -1,29 +1,61 @@
 {
     "errors": [
         {
-            "op": { "op": "replace", "path": "/x/y", "value": 42 },
+            "op": {
+                "op": "replace",
+                "path": "/x/y",
+                "value": 42,
+                "oldValue": {
+                    "x": {}
+                }
+            },
             "node": { "x": {} },
             "message": "jsonPatch.noSuchPath"
         }
     ],
     "ops": [
         {
-            "op": { "op": "replace", "path": "", "value": false },
+            "op": {
+                "op": "replace",
+                "path": "",
+                "value": false,
+                "oldValue": {
+                    "x": {
+                        "a": "b",
+                        "y": {}
+                    }
+                }
+            },
             "node": { "x": { "a": "b", "y": {} } },
             "expected": false
         },
         {
-            "op": { "op": "replace", "path": "/x/y", "value": "hello" },
+            "op": {
+                "op": "replace",
+                "path": "/x/y",
+                "value": "hello",
+                "oldValue": {}
+            },
             "node": { "x": { "a": "b", "y": {} } },
             "expected": { "x": { "a": "b", "y": "hello" } }
         },
         {
-            "op": { "op": "replace", "path": "/0/2", "value": "x" },
+            "op": {
+                "op": "replace",
+                "path": "/0/2",
+                "value": "x",
+                "oldValue": "c"
+            },
             "node": [ [ "a", "b", "c"], "d", "e" ],
             "expected": [ [ "a", "b", "x" ], "d", "e" ]
         },
         {
-            "op": { "op": "replace", "path": "/x/0", "value": null },
+            "op": {
+                "op": "replace",
+                "path": "/x/0",
+                "value": null,
+                "oldValue": "y"
+            },
             "node": { "x": [ "y", "z" ], "foo": "bar" },
             "expected": { "x": [ null, "z" ], "foo": "bar" }
         }


### PR DESCRIPTION
This violates the JSON Patch spec insofar as the spec does not define an `oldValue` entry in addition to the `value` entry, but is convenient for my use-case.

There exists an opportunity for improvement in future work wherein one might make this behavior toggle-able (`RFC-6902-strict` vs `RFC-6902-withReplacedValues`.)